### PR TITLE
New server IP address. Fixes for params

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,18 @@
-REPEAT_DELAY_SECONDS = 60
-SENSOR_TYPE_TO_PIN_NUM = {'MQ-2': 1, 'MQ-9': 2, 'MQ-135': 3}
 DEVICE_ID = 'RaspPi-Prototype-1'
 LAT = '34.0376455'
 LON = '-118.437404'
 BASE_URL = 'http://34.223.248.143/readings/calculate'
+REPEAT_DELAY_SECONDS = 60
+SENSOR_TYPE_TO_PIN_NUM = {
+    'MQ-2': 1, 'MQ-9': 2, 'MQ-135': 3
+}
+SENSOR_TYPE_TO_LOAD_RESISTANCE = {
+    'MQ-2': 5, 'MQ-9': 18, 'MQ-135': 20
+}
+SENSOR_TYPE_TO_AIR_RESISTANCE_RATIO = {
+    'MQ-2': 9.48, 'MQ-9': 9.71, 'MQ-135': 3.59
+}
+
 
 import logging
 logging.basicConfig(filename="gas_readings.log",

--- a/config.py
+++ b/config.py
@@ -3,7 +3,7 @@ SENSOR_TYPE_TO_PIN_NUM = {'MQ-2': 1, 'MQ-9': 2, 'MQ-135': 3}
 DEVICE_ID = 'RaspPi-Prototype-1'
 LAT = '34.0376455'
 LON = '-118.437404'
-BASE_URL = 'http://54.244.200.105/readings/calculate'
+BASE_URL = 'http://34.223.248.143/readings/calculate'
 
 import logging
 logging.basicConfig(filename="gas_readings.log",

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 DEVICE_ID = 'RaspPi-Prototype-1'
 LAT = '34.0376455'
 LON = '-118.437404'
-BASE_URL = 'http://34.223.248.143/readings/calculate'
+SERVER_URL = 'http://34.223.248.143/readings/calculate'
 REPEAT_DELAY_SECONDS = 60
 SENSOR_TYPE_TO_PIN_NUM = {
     'MQ-2': 1, 'MQ-9': 2, 'MQ-135': 3

--- a/read_sensors.py
+++ b/read_sensors.py
@@ -11,7 +11,7 @@ import time
 import requests
 import spidev
 
-from config import REPEAT_DELAY_SECONDS, BASE_URL, DEVICE_ID, LAT, LON, \
+from config import REPEAT_DELAY_SECONDS, SERVER_URL, DEVICE_ID, LAT, LON, \
     SENSOR_TYPE_TO_PIN_NUM, SENSOR_TYPE_TO_LOAD_RESISTANCE, \
     SENSOR_TYPE_TO_AIR_RESISTANCE_RATIO
 
@@ -78,7 +78,7 @@ def upload(sensor_type, reading, ro=None):
     )
     if ro is not None:
         data['ro'] = ro
-    response = requests.post(BASE_URL, data=data)
+    response = requests.post(SERVER_URL, data=data)
     response.raise_for_status()
 
 

--- a/read_sensors.py
+++ b/read_sensors.py
@@ -12,7 +12,8 @@ import requests
 import spidev
 
 from config import REPEAT_DELAY_SECONDS, BASE_URL, DEVICE_ID, LAT, LON, \
-    SENSOR_TYPE_TO_PIN_NUM
+    SENSOR_TYPE_TO_PIN_NUM, SENSOR_TYPE_TO_LOAD_RESISTANCE, \
+    SENSOR_TYPE_TO_AIR_RESISTANCE_RATIO
 
 
 parser = argparse.ArgumentParser(
@@ -56,7 +57,9 @@ def calibrate(sensor_type):
     if val == 0:
         val += 0.0000001
 
-    ro = (1023 / val - 1) * 5 / 9.48
+    lr = SENSOR_TYPE_TO_LOAD_RESISTANCE[sensor_type]
+    arr = SENSOR_TYPE_TO_AIR_RESISTANCE_RATIO[sensor_type]
+    ro = (1023 / val - 1) * lr / arr
 
     print('Val:', val, 'Ro:', ro)
     logging.info('Ro=%g' % ro)

--- a/read_sensors.py
+++ b/read_sensors.py
@@ -19,12 +19,6 @@ parser = argparse.ArgumentParser(
     description='Read gas sensors ' + ', '.join(SENSOR_TYPE_TO_PIN_NUM)
     + '\nTo configure, edit file config.py.'
 )
-parser.add_argument('-c', '--calibrate', action='store_true',
-                    help='Calibrate sensors before reading')
-parser.add_argument('-u', '--upload', action='store_true',
-                    help='Upload readings to configured Web site: ' + BASE_URL)
-
-
 spi = spidev.SpiDev()
 spi.open(0, 0)
 
@@ -65,14 +59,14 @@ def calibrate(sensor_type):
     ro = (1023 / val - 1) * 5 / 9.48
 
     print('Val:', val, 'Ro:', ro)
-    logging.info('Ro %g' % ro)
+    logging.info('Ro=%g' % ro)
 
     return ro
 
 
 def upload(sensor_type, reading, ro=None):
-    params = dict(
-        device_id=DEVICE_ID,
+    data = dict(
+        deviceId=DEVICE_ID,
         instant='now',
         latitude=LAT,
         longitude=LON,
@@ -80,28 +74,29 @@ def upload(sensor_type, reading, ro=None):
         reading=reading,
     )
     if ro is not None:
-        params['ro'] = ro
-    response = requests.get(BASE_URL, params=params)
+        data['ro'] = ro
+    response = requests.post(BASE_URL, data=data)
     response.raise_for_status()
 
 
-def run(should_calibrate, should_upload):
+def run(should_calibrate=True):
     try:
         print('Press Ctrl+C to abort')
         logging.info('Program started')
 
-        ros = [calibrate(t) if should_calibrate else None
-               for t in SENSOR_TYPE_TO_PIN_NUM]
+        if should_calibrate:
+            ros = [calibrate(t) for t in SENSOR_TYPE_TO_PIN_NUM]
+        else:
+            ros = [None, None, None]
 
-        print('\n\nRead sensors every %s seconds...' % REPEAT_DELAY_SECONDS)
+        print('\nRead sensors every %s seconds...' % REPEAT_DELAY_SECONDS)
         while True:
             sys.stdout.write('\r\033[K')
             for sensor_type, ro in zip(SENSOR_TYPE_TO_PIN_NUM, ros):
                 val = read_adc(sensor_type)
                 sys.stdout.write('%s:%g ' % (sensor_type, val))
                 sys.stdout.flush()
-                if should_upload:
-                    upload(val, ro)
+                upload(sensor_type, val, ro)
                 time.sleep(REPEAT_DELAY_SECONDS)
 
     except KeyboardInterrupt:
@@ -111,4 +106,4 @@ def run(should_calibrate, should_upload):
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    run(args.calibrate, args.upload)
+    run()


### PR DESCRIPTION
Tested with `curl --header 'Accept: application/json' 'http://34.223.248.143/readings?gasName=all&startDateTime=dayago&endDateTime=now&sensorType=MQ-9&deviceId=RaspPi-Prototype-2' | jq '.[0:3]'`

Where the device ID was set to `RaspPi-Prototype-2` (see the current file on @diegoew 's device).