### PR TITLE
Send explicit timestamps in requests to server

### DIFF
--- a/read_sensors.py
+++ b/read_sensors.py
@@ -4,6 +4,7 @@ Script to periodically read gas concentration measurements from sensors and
 optionally upload them to a Web service.
 """
 import argparse
+from datetime import datetime, timezone
 import logging
 import sys
 import time
@@ -70,7 +71,7 @@ def calibrate(sensor_type):
 def upload(sensor_type, reading, ro=None):
     data = dict(
         deviceId=DEVICE_ID,
-        instant='now',
+        instant=datetime.now(timezone.utc).astimezone().isoformat(),
         latitude=LAT,
         longitude=LON,
         sensorType=sensor_type,

--- a/read_sensors.py
+++ b/read_sensors.py
@@ -17,6 +17,8 @@ from config import REPEAT_DELAY_SECONDS, SERVER_URL, DEVICE_ID, LAT, LON, \
     SENSOR_TYPE_TO_AIR_RESISTANCE_RATIO
 
 
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S%z'
+
 parser = argparse.ArgumentParser(
     description='Read gas sensors ' + ', '.join(SENSOR_TYPE_TO_PIN_NUM)
     + '\nTo configure, edit file config.py.'
@@ -68,10 +70,15 @@ def calibrate(sensor_type):
     return ro
 
 
+def timestamp():
+    td_str = datetime.now(timezone.utc).astimezone().strftime(DATETIME_FORMAT)
+    return td_str[:-2] + ':' + td_str[-2:]
+
+
 def upload(sensor_type, reading, ro=None):
     data = dict(
         deviceId=DEVICE_ID,
-        instant=datetime.now(timezone.utc).astimezone().isoformat(),
+        instant=timestamp(),
         latitude=LAT,
         longitude=LON,
         sensorType=sensor_type,


### PR DESCRIPTION
As per [Swagger spec](http://34.223.248.143/swagger-ui.html#!/gas45level45controller/readingsWriteAfterCalculationUsingPOST), include timestamps in UTC format (without microseconds) in requests to server. Example: `2018-07-23T16:58:24-07:00`.