### PR TITLE
Server: expect and always use resolution param

### DIFF
--- a/api/src/main/java/org/protectplayanow/api/gaslevel/Reading.java
+++ b/api/src/main/java/org/protectplayanow/api/gaslevel/Reading.java
@@ -78,9 +78,7 @@ public class Reading {
 
         double roFromDefaultOrRecievedValue = ro;
 
-        double res = (getDeviceId().equals("RaspPi-Vlad-old-script")||getDeviceId().equals("RaspPi-Prototype-1")) ? 1023 : resolution;
-
-        double rs_over_ro = ((((res/input)-1)*loadResistance)/roFromDefaultOrRecievedValue)
+        double rs_over_ro = ((((resolution/input)-1)*loadResistance)/roFromDefaultOrRecievedValue)
                             /
                             ((.00007*(this.relativeHumidity*100)-.0158)*this.tempInCelsius + (-(.0074*this.relativeHumidity*100) + 1.7761));
 
@@ -103,7 +101,7 @@ public class Reading {
                     .longitude(this.longitude)
                     .relativeHumidity(this.relativeHumidity)
                     .tempInCelsius(this.tempInCelsius)
-                    .resolution(res)
+                    .resolution(resolution)
                     .ro(roFromDefaultOrRecievedValue)
                     .input(input)
                     .unitOfReading("ppm")


### PR DESCRIPTION
Removes hack in server code because the client (monitor) code no longer requires it.

NOTE: Before deploying this code, update Vlad's monitor and GM1 to use the latest monitor code.