### PR TITLE
Faster retrieval of devices list

### DIFF
--- a/api/chart/chart.html
+++ b/api/chart/chart.html
@@ -23,7 +23,6 @@
     <script>
     var urlBase = "34.223.248.143";
     var theDataType = "reading";
-    <!--var urlBase = "localhost:8080";-->
 /*******/
 $( function() {
     $( "#startPicker" ).datepicker({
@@ -176,50 +175,28 @@ $( function() {
         theChart = chart;
         theOptions = options;
     }
-    /****/
-    function makeUnique(list) {
-      var result = [];
-      $.each(list, function(i, e) {
-        if ($.inArray(e, result) == -1) result.push(e);
-      });
-      return result;
+    
+function populateDevices() {
+  var $dropdown = $("#devices");
+  var url = "http://" + urlBase + "/devices?ids=true";
+  $.getJSON(url, function(devIds) {
+    var idsRaspPi = [];
+    var idsOther = [];
+    for (i = 0; i < devIds.length; i++) {
+      if (devIds[i].startsWith("RaspPi")) {
+        idsRaspPi.push(devIds[i]);
+      } else if (!devIds[i].startsWith("zTest")) {
+        idsOther.push(devIds[i]);
+      }
     }
-   function populateDevices(){
-    var $dropdown = $("#devices");
-    var url = "http://" + urlBase + "/devices";
-    $.getJSON( url, function( dataReturned ) {
-        var lastElem = dataReturned[dataReturned.length-1];
-        console.log("ajax device request returned dataReturned size: " + dataReturned.length);
-        var deviceIds = [];
-        for( i = 0; i < dataReturned.length; i++ ) {
-            //console.log("deviceId: " + dataReturned[i].deviceId);
-            deviceIds.push(dataReturned[i].deviceId);
-        }
-        //console.log("deviceIds size: " + deviceIds.length);
-        var devIds = makeUnique(deviceIds);
-        deviceIdsRaspPi = [];
-        deviceIdsOther = [];
-        for( i = 0; i < devIds.length; i++ ) {
-            if(devIds[i].includes("RaspPi")){
-                deviceIdsRaspPi.push(devIds[i]);
-            } else if(devIds[i].includes("zTest")){
-                //skip and don't display these devices, they are from the unit tests
-            } else {
-                deviceIdsOther.push(devIds[i]);
-            }
-        }
-        deviceIdsOther.sort();
-        deviceIdsRaspPi.sort();
-        console.log("deviceIds post unique size: " + devIds.length);
-        //console.log("devIds: " + devIds);
-        for( i = 0; i < deviceIdsRaspPi.length; i++ ) {
-            $dropdown.append($("<option />").val(deviceIdsRaspPi[i]).text(deviceIdsRaspPi[i]));
-        }
-        for( i = 0; i < deviceIdsOther.length; i++ ) {
-            $dropdown.append($("<option />").val(deviceIdsOther[i]).text(deviceIdsOther[i]));
-        }
-    });
-  }
+    for(i = 0; i < idsRaspPi.length; i++) {
+      $dropdown.append($("<option />").val(idsRaspPi[i]).text(idsRaspPi[i]));
+    }
+    for(i = 0; i < idsOther.length; i++) {
+      $dropdown.append($("<option />").val(idsOther[i]).text(idsOther[i]));
+    }
+  });
+}
       function grabDataFromServer(startDate, endDate, chart, options) {
         //disable all buttons until data returns
         $(':button').prop('disabled', true);

--- a/api/src/main/java/org/protectplayanow/api/config/Constants.java
+++ b/api/src/main/java/org/protectplayanow/api/config/Constants.java
@@ -72,6 +72,12 @@ public class Constants {
             apiGasMessage = "pass in strings " + Constants.gasKeys + ", or other gas names that sensors have reported"
             ;
 
+    public static final String
+        apiIdsMessage = "pass in string true to get a list of only device IDs" 
+            ;
+
+    public static final String
+        apiRemoveIfIdStartsWithMessage = "Remove results whose device ID starts with this string";
 
     public static final String
             sensorTypeMsg = "must have value " + sensorTypeList;;

--- a/api/src/main/java/org/protectplayanow/api/gaslevel/GasLevelController.java
+++ b/api/src/main/java/org/protectplayanow/api/gaslevel/GasLevelController.java
@@ -114,21 +114,24 @@ public class GasLevelController {
 
     }
 
-
     @ApiOperation(value = "This endpoint allows you to get a list of unique deviceIds, sensorType, latidude, longitude.")
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "Well done!"),
             @ApiResponse(code = 500, message = "Server error a.k.a. royal screwup!")})
     @RequestMapping(value = "/devices", method = RequestMethod.GET)
-    public ResponseEntity<List<DeviceForRest>> getDevices(){
-
-        HttpHeaders responseHeaders = Constants.makeGlobalHeaders(globalValueMap.get(Constants.secondsBetweenReadings));
-
-        return new ResponseEntity<List<DeviceForRest>>(
-                DeviceForRest.make(gasLevelRepo.getDevices()),
-                responseHeaders,
+    public ResponseEntity<List> getDevices(
+            @ApiParam(value = Constants.apiIdsMessage)
+            @RequestParam(value = "ids", defaultValue = "false", required = false) boolean shouldIncludeIds
+    ) {
+        if (shouldIncludeIds) {
+            return new ResponseEntity<List>(
+                gasLevelRepo.getDeviceIds(),
                 HttpStatus.OK);
-
+        } else {
+            return new ResponseEntity<List>(
+                DeviceForRest.make(gasLevelRepo.getDevices()),
+                HttpStatus.OK);
+        }
     }
 
     @ApiResponses(value = {

--- a/api/src/main/java/org/protectplayanow/api/gaslevel/GasLevelRepo.java
+++ b/api/src/main/java/org/protectplayanow/api/gaslevel/GasLevelRepo.java
@@ -16,4 +16,5 @@ public interface GasLevelRepo {
 
     List<Device> getDevices();
 
+    List<String> getDeviceIds();
 }

--- a/api/src/main/java/org/protectplayanow/api/gaslevel/repository/GasLevelAuroraRepo.java
+++ b/api/src/main/java/org/protectplayanow/api/gaslevel/repository/GasLevelAuroraRepo.java
@@ -111,6 +111,19 @@ public class GasLevelAuroraRepo implements GasLevelRepo {
     }
 
     @Override
+    public List<String> getDeviceIds() {
+        List<String> ids = new ArrayList<>();
+        jdbcTemplate.query(
+                "SELECT DISTINCT deviceId FROM reading ORDER BY deviceId ASC",
+                new Object[] { },
+                (rs, rowNum) -> rs.getString("deviceId")
+        ).forEach(id -> {
+            ids.add(id.toString());
+        });
+        return ids;
+    }
+
+    @Override
     public void saveGasReadings(List<Reading> readings) {
         String q = " INSERT INTO reading " +
                 " (instant, deviceId, gasName, reading, unitOfReading, latitude, longitude, sensorType, ro, relHumidity, tempInCelsius, input, resolution) " +

--- a/api/src/test/java/org/protectplayanow/api/GasLevelControllerTest.java
+++ b/api/src/test/java/org/protectplayanow/api/GasLevelControllerTest.java
@@ -119,6 +119,19 @@ public class GasLevelControllerTest {
     }
 
     @Test
+    public void testGettingDeviceIds()  {
+        ResponseEntity<String> forEntity = restTemplate.getForEntity(urlBase + port + "/devices?ids=true", String.class);
+        log.info("\n\nresp: {}\n", forEntity.getBody());
+        ResponseEntity<List<String>> response = restTemplate.exchange(
+                urlBase + port + "/devices?ids=true",
+                HttpMethod.GET, null,
+                new ParameterizedTypeReference<List<String>>(){});
+        List<String> deviceIds = response.getBody();
+        log.info("\n\nresp: {}\n", deviceIds);
+        Assert.assertTrue("we got back some devices", deviceIds.size() > 0);
+    }
+
+    @Test
     public void testSendingNewReading()  {
 
         String randomDwviceId = "zTest" + new Date().toString().replace(" ", "");


### PR DESCRIPTION
Implements solution 2 for Task [website loading speed](https://trello.com/c/regMVMX0/20-website-loading-speed )

Improves response time for device names from ~50s to < 2s with currently stored data.

VNC into RaspPi-GasMonitor03 and try this in the browser: http://localhost:8080/devices?ids=true